### PR TITLE
Adding support for nested objects

### DIFF
--- a/src/jsonlog.erl
+++ b/src/jsonlog.erl
@@ -60,7 +60,11 @@ format_log([TemplateKey | Rest], Config, Msg, Meta, Acc) ->
             format_log(Rest, Config, Msg, Meta, Acc#{TemplateKey => format_val(TemplateKey, Val, Config)})
     end.
 
-%%
+%%====================================================================
+%% Internal functions
+%%====================================================================
+format_log_internal(Tpl, Config, Msg, Meta) ->
+    format_log(Tpl, Config, Msg, Meta, #{}).
 
 apply_defaults(Map) ->
     maps:merge(
@@ -84,6 +88,11 @@ format_val(time, Time, Config) ->
     format_time(Time, Config);
 format_val(mfa, MFA, Config) ->
     format_mfa(MFA, Config);
+% Format recursively for nested objects.
+format_val(_Key, Val, Config) when is_map(Val) ->
+    Keys = maps:keys(Val),
+    TemplateKeys = lists:zip(Keys, Keys),
+    format_log_internal(TemplateKeys, Config, Val, Val);
 format_val(_Key, Val, _Config) ->
     jsonlog_utils:to_string(Val).
 

--- a/test/jsonlog_SUITE.erl
+++ b/test/jsonlog_SUITE.erl
@@ -51,6 +51,29 @@ format(Config) ->
                                   json_encode => Encoder}),
     ?assertEqual(#{<<"body">> => <<"{foo}">>, <<"c">> => <<"d">>}, decode(Formatted4)),
 
+    Map2 = #{e => #{f => g}},
+
+    Formatted5 = jsonlog:format(#{level => info, msg => {report, Map2}, meta => #{c => d}},
+                                #{template => [{my_value, msg}],
+                                  json_encode => Encoder}),
+    ?assertEqual(#{<<"my_value">> => #{<<"e">> => #{<<"f">> => <<"g">>}}}, decode(Formatted5)),
+
+    Map3 = #{e => #{f => #{g => h}}, i => #{j => k}},
+
+    Formatted6 = jsonlog:format(#{level => info, msg => {report, Map3}, meta => #{c => Map3}},
+                                #{template => [c],
+                                  json_encode => Encoder}),
+    ?assertEqual(#{<<"c">> => #{<<"e">> => #{<<"f">> => #{<<"g">> => <<"h">>}}, <<"i">> => #{<<"j">> => <<"k">>}}}, decode(Formatted6)),
+
+    Formatted7 = jsonlog:format(#{level => info, msg => {report, Map3}, meta => #{c => Map3}},
+                                #{template => [{c, c}, {msg, msg}],
+                                  json_encode => Encoder}),
+    ?assertEqual(
+        #{
+            <<"msg">> => #{<<"e">> => #{<<"f">> => #{<<"g">> => <<"h">>}}, <<"i">> => #{<<"j">> => <<"k">>}},
+            <<"c">> => #{<<"e">> => #{<<"f">> => #{<<"g">> => <<"h">>}}, <<"i">> => #{<<"j">> => <<"k">>}}
+        }, decode(Formatted7)),
+
     ok.
 
 %%


### PR DESCRIPTION
Currently this library serializes nested maps as the Erlang string representation of a map. This PR extends the library to support nested JSON objects for both a message body and a meta body.